### PR TITLE
Audit Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-
 # Created by https://www.toptal.com/developers/gitignore/api/soliditytruffle,solidity,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=soliditytruffle,solidity,node
 
 .openzeppelin
 
 log.txt
+
+local-setup.devnet.sh
 
 ### Node ###
 # Logs

--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -152,7 +152,12 @@ contract DLCManager is
     ) private view returns (bytes32) {
         return
             keccak256(
-                abi.encodePacked(sender, nonce, blockhash(block.number - 1))
+                abi.encodePacked(
+                    sender,
+                    nonce,
+                    blockhash(block.number - 1),
+                    block.chainid
+                )
             );
     }
 

--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -76,6 +76,8 @@ contract DLCManager is
     error DuplicateSignature();
     error SignerNotApproved(address signer);
 
+    error InvalidRange();
+
     ////////////////////////////////////////////////////////////////
     //                         MODIFIERS                          //
     ////////////////////////////////////////////////////////////////
@@ -333,10 +335,16 @@ contract DLCManager is
         return dlcs[index];
     }
 
-    function getFundedTxIds() public view returns (string[] memory) {
-        string[] memory _fundedTxIds = new string[](_index);
+    function getFundedTxIds(
+        uint256 startIndex,
+        uint256 endIndex
+    ) public view returns (string[] memory) {
+        if (startIndex >= endIndex) revert InvalidRange();
+        if (endIndex > _index) revert InvalidRange();
+        uint256 _indexRange = endIndex - startIndex;
+        string[] memory _fundedTxIds = new string[](_indexRange);
         uint256 _fundedTxIdsCount = 0;
-        for (uint256 i = 0; i < _index; i++) {
+        for (uint256 i = startIndex; i < endIndex; i++) {
             if (dlcs[i].status == DLCLink.DLCStatus.FUNDED) {
                 _fundedTxIds[_fundedTxIdsCount] = dlcs[i].fundingTxId;
                 _fundedTxIdsCount++;

--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -54,6 +54,7 @@ contract DLCManager is
     uint16 private _signerCount;
     mapping(bytes32 => uint256) private _signatureCounts;
     bytes32 public tssCommitment;
+    uint256[50] __gap;
 
     ////////////////////////////////////////////////////////////////
     //                           ERRORS                           //

--- a/contracts/TokenManager.sol
+++ b/contracts/TokenManager.sol
@@ -80,6 +80,8 @@ contract TokenManager is
     error DepositTooLarge(uint256 deposit, uint256 maximumDeposit);
     error InsufficientTokenBalance(uint256 balance, uint256 amount);
 
+    error FeeRateOutOfBounds(uint256 feeRate);
+
     ////////////////////////////////////////////////////////////////
     //                         MODIFIERS                          //
     ////////////////////////////////////////////////////////////////
@@ -335,6 +337,7 @@ contract TokenManager is
     }
 
     function setMintFeeRate(uint256 newMintFeeRate) external onlyDLCAdmin {
+        if (newMintFeeRate > 10000) revert FeeRateOutOfBounds(newMintFeeRate);
         mintFeeRate = newMintFeeRate;
         emit SetMintFeeRate(newMintFeeRate);
     }
@@ -347,6 +350,8 @@ contract TokenManager is
     function setBtcMintFeeRate(
         uint256 newBtcMintFeeRate
     ) external onlyDLCAdmin {
+        if (newBtcMintFeeRate > 10000)
+            revert FeeRateOutOfBounds(newBtcMintFeeRate);
         btcMintFeeRate = newBtcMintFeeRate;
         emit SetBtcMintFeeRate(newBtcMintFeeRate);
     }

--- a/contracts/TokenManager.sol
+++ b/contracts/TokenManager.sol
@@ -65,6 +65,7 @@ contract TokenManager is
 
     mapping(address => bytes32[]) public userVaults;
     mapping(address => bool) private _whitelistedAddresses;
+    uint256[50] __gap;
 
     ////////////////////////////////////////////////////////////////
     //                           ERRORS                           //

--- a/contracts/mocks/TokenManagerTest.sol
+++ b/contracts/mocks/TokenManagerTest.sol
@@ -27,7 +27,7 @@ import "../DLCLinkLibrary.sol";
  * @dev     It is upgradable through the OpenZeppelin proxy pattern
  * @dev     Launched with Whitelisted useraddresses enabled first
  * @dev     It is extendable to allow taking fees during vault creation and/or during DLC closing.
- * @dev     It is governed by the DLC_ADMIN_ROLE, a multisig
+ * @dev     It is governed by the DLC_ADMIN_ROLE, a multisig wallet
  * @custom:contact robert@dlc.link
  * @custom:website https://www.dlc.link
  */
@@ -55,6 +55,7 @@ contract TokenManagerV2Test is
     DLCBTC public dlcBTC; // dlcBTC contract
     IDLCManager public dlcManager; // DLCManager contract
     string private _btcFeeRecipient; // BTC address to send fees to
+    address public feeRecipient; // address to send fees to
     uint256 public minimumDeposit; // in sats
     uint256 public maximumDeposit; // in sats
     uint256 public mintFeeRate; // in basis points (10000 = 100%) -- dlcBTC
@@ -116,10 +117,10 @@ contract TokenManagerV2Test is
         _grantRole(PAUSER_ROLE, adminAddress);
         dlcManager = IDLCManager(dlcManagerAddress);
         dlcBTC = tokenContract;
-        // NOTE:
         minimumDeposit = 1000; // 0.00001 BTC
         maximumDeposit = 1e9; // 10 BTC
         mintFeeRate = 0; // 0% dlcBTC fee for now
+        feeRecipient = adminAddress; // default to admin address
         whitelistingEnabled = true;
         btcMintFeeRate = 100; // 1% BTC fee for now
         btcRedeemFeeRate = 100; // 1% BTC fee for now
@@ -152,6 +153,7 @@ contract TokenManagerV2Test is
     event SetMinimumDeposit(uint256 newMinimumDeposit);
     event SetMaximumDeposit(uint256 newMaximumDeposit);
     event SetMintFeeRate(uint256 newMintFeeRate);
+    event SetFeeRecipient(address newFeeRecipient);
     event SetBtcMintFeeRate(uint256 newBtcMintFeeRate);
     event SetBtcRedeemFeeRate(uint256 newBtcRedeemFeeRate);
     event SetBtcFeeRecipient(string btcFeeRecipient);
@@ -228,8 +230,11 @@ contract TokenManagerV2Test is
         string calldata btcTxId
     ) external override whenNotPaused onlyDLCManagerContract {
         DLCLink.DLC memory dlc = dlcManager.getDLC(uuid);
+        uint256 _feeAdjustedAmount = _getFeeAdjustedAmount(dlc.valueLocked);
+        uint256 _fee = dlc.valueLocked - _feeAdjustedAmount;
 
-        _mintTokens(dlc.creator, _getFeeAdjustedAmount(dlc.valueLocked));
+        _mintTokens(dlc.creator, _feeAdjustedAmount);
+        _mintTokens(feeRecipient, _fee);
         emit SetStatusFunded(uuid, btcTxId, dlc.creator);
     }
 
@@ -293,7 +298,7 @@ contract TokenManagerV2Test is
         return _getFeeAdjustedAmount(amount);
     }
 
-    function newTestFunction() external pure returns (uint256) {
+    function newTestFunction() public pure returns (uint) {
         return 1;
     }
 
@@ -332,6 +337,11 @@ contract TokenManagerV2Test is
     function setMintFeeRate(uint256 newMintFeeRate) external onlyDLCAdmin {
         mintFeeRate = newMintFeeRate;
         emit SetMintFeeRate(newMintFeeRate);
+    }
+
+    function setFeeRecipient(address newFeeRecipient) external onlyDLCAdmin {
+        feeRecipient = newFeeRecipient;
+        emit SetFeeRecipient(newFeeRecipient);
     }
 
     function setBtcMintFeeRate(

--- a/contracts/mocks/TokenManagerTest.sol
+++ b/contracts/mocks/TokenManagerTest.sol
@@ -65,6 +65,8 @@ contract TokenManagerV2Test is
 
     mapping(address => bytes32[]) public userVaults;
     mapping(address => bool) private _whitelistedAddresses;
+    uint256 someNewVar;
+    uint256[49] __gap;
 
     ////////////////////////////////////////////////////////////////
     //                           ERRORS                           //

--- a/scripts/05-add-signer.js
+++ b/scripts/05-add-signer.js
@@ -27,7 +27,10 @@ module.exports = async function addSigner(signer, version) {
     ) {
         console.log('admin has DEFAULT_ADMIN_ROLE, adding signer');
 
-        await dlcManager.addApprovedSigner(signer);
+        await dlcManager.grantRole(
+            hardhat.ethers.utils.id('APPROVED_SIGNER'),
+            signer
+        );
 
         console.log('Added: ', signer);
     } else {
@@ -37,7 +40,10 @@ module.exports = async function addSigner(signer, version) {
 
         const txRequest = await dlcManager
             .connect(admin)
-            .populateTransaction.addApprovedSigner(signer);
+            .populateTransaction.grantRole(
+                hardhat.ethers.utils.id('APPROVED_SIGNER'),
+                signer
+            );
         await safeContractProposal(txRequest, admin);
     }
 };

--- a/scripts/06-remove-signer.js
+++ b/scripts/06-remove-signer.js
@@ -27,7 +27,10 @@ module.exports = async function removeSigner(signer, version) {
     ) {
         console.log('admin has DEFAULT_ADMIN_ROLE, removing signer');
 
-        await dlcManager.removeApprovedSigner(signer);
+        await dlcManager.revokeRole(
+            hardhat.ethers.utils.id('APPROVED_SIGNER'),
+            signer
+        );
 
         console.log('Added: ', signer);
     } else {
@@ -37,7 +40,10 @@ module.exports = async function removeSigner(signer, version) {
 
         const txRequest = await dlcManager
             .connect(admin)
-            .populateTransaction.removeApprovedSigner(signer);
+            .populateTransaction.revokeRole(
+                hardhat.ethers.utils.id('APPROVED_SIGNER'),
+                signer
+            );
         await safeContractProposal(txRequest, admin);
     }
 };

--- a/test/DLCManager.test.js
+++ b/test/DLCManager.test.js
@@ -532,7 +532,6 @@ describe('DLCManager', () => {
             const decodedEvent = dlcManager.interface.parseLog(event);
             const newUuid = decodedEvent.args.uuid;
 
-            await setSigners(dlcManager, attestors);
             const { prefixedMessageHash, signatureBytes } = await getSignatures(
                 { uuid: newUuid, btcTxId: closingBtcTxId },
                 attestors,
@@ -588,7 +587,6 @@ describe('DLCManager', () => {
         });
 
         it('emits a PostCloseDLC event with the correct data', async () => {
-            await setSigners(dlcManager, attestors);
             const { prefixedMessageHash, signatureBytes } = await getSignatures(
                 { uuid, btcTxId: closingBtcTxId },
                 attestors,

--- a/test/TokenManager.test.js
+++ b/test/TokenManager.test.js
@@ -108,6 +108,14 @@ describe('TokenManager', function () {
                         .setMintFeeRate(someRandomAccount.address)
                 ).to.be.revertedWithCustomError(tokenManager, 'NotDLCAdmin');
             });
+            it('reverts on invalid fee rate', async () => {
+                await expect(
+                    tokenManager.connect(deployer).setMintFeeRate(10001)
+                ).to.be.revertedWithCustomError(
+                    tokenManager,
+                    'FeeRateOutOfBounds'
+                );
+            });
             it('should set mint fee rate', async () => {
                 await tokenManager.connect(deployer).setMintFeeRate(1000);
                 expect(await tokenManager.mintFeeRate()).to.equal(1000);


### PR DESCRIPTION
> ### MSA001 Discussion: When the whitelisted contracts are the approved signers

> ### MSA002 Probably mis-calculate the \_signerCount

Fixed in [4e6e428](https://github.com/DLC-link/dlc-solidity/pull/43/commits/4e6e428e714ab4d44d29d1c32d6eb9446352b1a9). Added an extra role based check in [08ad245](https://github.com/DLC-link/dlc-solidity/pull/43/commits/08ad24555bea64d5a678f1a68c88165af4922217), wherein no ROLE holder can hold any other major ROLE.

> ### MSA003 Centralized Roles

Not really an issue: while the DLCAdmin role seems centralized, this will be a Gnosis SAFE Multisig account. We would post the members/threshold of this multisig on our public channels for providing trust. Eventually, it could be delegated to a DAO or a multisig contract.

> ### MSA004 The improper values of the \_threshold and the \_minimumThreshold may block the \_attestorMultisigIsValid function

We want signing to fail if the signatures are less than the threshold, so this is not an issue. Most of the threshold potential errors were mitigated in  [4e6e428](https://github.com/DLC-link/dlc-solidity/pull/43/commits/4e6e428e714ab4d44d29d1c32d6eb9446352b1a9) using the ROLE based signers approach.

> ### MSA005 The mint fee does not be sent to the fee recipient

Fixed in  [45ed634](https://github.com/DLC-link/dlc-solidity/pull/43/commits/45ed634b84e537b6201d27af721df22ca0d71c77) 

> ### MSA006 Potential being out of gas as the increasement of dlcs

Fixed in [a5ee452](https://github.com/DLC-link/dlc-solidity/pull/43/commits/a5ee45262973ac0d80e0894c59787a8d076b0ad5)

> ### MSA007 Upgradeable contracts missing a storage gap variable \_\_gap[50]

Fixed in [7a42606](https://github.com/DLC-link/dlc-solidity/pull/43/commits/7a42606b39c0f25639f241bb7b87f2b961690947)

> ### MSA008 Lack of validating the \_threshold

Added a check in [08ad245](https://github.com/DLC-link/dlc-solidity/pull/43/commits/08ad24555bea64d5a678f1a68c88165af4922217)

> ### MSA009 Gas optimazation

Irrelevant after MSA006

> ### MSA010 Combining the chain id and contract address when calculating the UUID

Fixed in [1e7b04d](https://github.com/DLC-link/dlc-solidity/pull/43/commits/1e7b04de83dadba8aa4bd46b264dbc8729c2e163)

> ### MSA011 Lack of the fee rate boundary

Fixed in [c00c66d](https://github.com/DLC-link/dlc-solidity/pull/43/commits/c00c66da585a4facad80041af8e966a081c62fad)

> ### MSA012 Discussion: Unused variables

These variables are read and used off-chain from the EVM perspective.

## Additional notes

Please note that the DLCManager contract now includes a new field with an admin setter function: _tssCommitment_, added in #42. This is a variable used for aiding in the FROST resharing session. We can discuss in person in more detail.
