### PR TITLE
fix: commitment to bytes script

### DIFF
--- a/scripts/08-set-tss-commitment.js
+++ b/scripts/08-set-tss-commitment.js
@@ -32,6 +32,9 @@ async function setTSSCommitment(timestamp) {
 
     if (timestamp) {
         commitment = timestamp;
+        commitmentBytes32 = ethers.utils.formatBytes32String(
+            commitment.toString()
+        );
     } else {
         const response = await prompts({
             type: 'select',


### PR DESCRIPTION
The new path of commitment setting introduced in #61 , where you can pass in a UNIX timestamp, was missing the conversion to bytes. This PR fixes that! 