### PR TITLE
Overloading mint & burn

### DIFF
--- a/contracts/DLCBTC.sol
+++ b/contracts/DLCBTC.sol
@@ -72,8 +72,16 @@ contract DLCBTC is
         _mint(to, amount);
     }
 
+    function mint(uint256 amount) external onlyMinterOrOwner {
+        _mint(msg.sender, amount);
+    }
+
     function burn(address from, uint256 amount) external onlyBurnerOrOwner {
         _burn(from, amount);
+    }
+
+    function burn(uint256 amount) external onlyBurnerOrOwner {
+        _burn(msg.sender, amount);
     }
 
     function blacklist(address account) external onlyOwner {

--- a/deploymentFiles/arbitrum/DLCBTC.json
+++ b/deploymentFiles/arbitrum/DLCBTC.json
@@ -1,7 +1,7 @@
 {
   "network": "arbitrum",
-  "updatedAt": "2024-04-13T10:52:17.411Z",
-  "gitSHA": "c9914ab",
+  "updatedAt": "2024-06-06T10:14:16.956Z",
+  "gitSHA": "cee21b3",
   "contract": {
     "name": "DLCBTC",
     "address": "0x050C24dBf1eEc17babE5fc585F06116A259CC77A",
@@ -26,6 +26,7 @@
       "function balanceOf(address account) view returns (uint256)",
       "function blacklist(address account)",
       "function blacklisted(address) view returns (bool)",
+      "function burn(uint256 amount)",
       "function burn(address from, uint256 amount)",
       "function decimals() view returns (uint8)",
       "function decreaseAllowance(address spender, uint256 subtractedValue) returns (bool)",
@@ -33,6 +34,7 @@
       "function increaseAllowance(address spender, uint256 addedValue) returns (bool)",
       "function initialize()",
       "function mint(address to, uint256 amount)",
+      "function mint(uint256 amount)",
       "function name() view returns (string)",
       "function nonces(address owner) view returns (uint256)",
       "function owner() view returns (address)",

--- a/deploymentFiles/arbsepolia/DLCBTC.json
+++ b/deploymentFiles/arbsepolia/DLCBTC.json
@@ -1,7 +1,7 @@
 {
   "network": "arbsepolia",
-  "updatedAt": "2024-05-20T12:56:48.538Z",
-  "gitSHA": "5afd44f",
+  "updatedAt": "2024-06-06T08:51:46.956Z",
+  "gitSHA": "cee21b3",
   "contract": {
     "name": "DLCBTC",
     "address": "0xFfb72b5f195F18741101A732e7AfAE72b61D48a4",
@@ -26,6 +26,7 @@
       "function balanceOf(address account) view returns (uint256)",
       "function blacklist(address account)",
       "function blacklisted(address) view returns (bool)",
+      "function burn(uint256 amount)",
       "function burn(address from, uint256 amount)",
       "function decimals() view returns (uint8)",
       "function decreaseAllowance(address spender, uint256 subtractedValue) returns (bool)",
@@ -33,6 +34,7 @@
       "function increaseAllowance(address spender, uint256 addedValue) returns (bool)",
       "function initialize()",
       "function mint(address to, uint256 amount)",
+      "function mint(uint256 amount)",
       "function name() view returns (string)",
       "function nonces(address owner) view returns (uint256)",
       "function owner() view returns (address)",

--- a/deploymentFiles/mainnet/DLCBTC.json
+++ b/deploymentFiles/mainnet/DLCBTC.json
@@ -1,7 +1,7 @@
 {
   "network": "mainnet",
-  "updatedAt": "2024-05-20T09:43:37.727Z",
-  "gitSHA": "5afd44f",
+  "updatedAt": "2024-06-06T10:11:27.227Z",
+  "gitSHA": "cee21b3",
   "contract": {
     "name": "DLCBTC",
     "address": "0x20157DBAbb84e3BBFE68C349d0d44E48AE7B5AD2",
@@ -26,6 +26,7 @@
       "function balanceOf(address account) view returns (uint256)",
       "function blacklist(address account)",
       "function blacklisted(address) view returns (bool)",
+      "function burn(uint256 amount)",
       "function burn(address from, uint256 amount)",
       "function decimals() view returns (uint8)",
       "function decreaseAllowance(address spender, uint256 subtractedValue) returns (bool)",
@@ -33,6 +34,7 @@
       "function increaseAllowance(address spender, uint256 addedValue) returns (bool)",
       "function initialize()",
       "function mint(address to, uint256 amount)",
+      "function mint(uint256 amount)",
       "function name() view returns (string)",
       "function nonces(address owner) view returns (uint256)",
       "function owner() view returns (address)",

--- a/test/DLCBTC.test.js
+++ b/test/DLCBTC.test.js
@@ -75,30 +75,30 @@ describe('DLCBTC', function () {
 
     it('should revert on unauthorized mint', async () => {
         await expect(
-            dlcBtc.connect(user).mint(user.address, deposit)
+            dlcBtc.connect(user)['mint(address,uint256)'](user.address, deposit)
         ).to.be.revertedWithCustomError(dlcBtc, 'NotAuthorized');
     });
 
     it('should revert on unauthorized burn', async () => {
         await expect(
-            dlcBtc.connect(user).burn(user.address, deposit)
+            dlcBtc.connect(user)['burn(address,uint256)'](user.address, deposit)
         ).to.be.revertedWithCustomError(dlcBtc, 'NotAuthorized');
     });
 
     it('owner can mint tokens', async () => {
-        await dlcBtc.mint(user.address, deposit);
+        await dlcBtc['mint(address,uint256)'](user.address, deposit);
         expect(await dlcBtc.balanceOf(user.address)).to.equal(deposit);
     });
 
     it('owner can burn tokens', async () => {
-        await dlcBtc.mint(user.address, deposit);
-        await dlcBtc.burn(user.address, deposit);
+        await dlcBtc['mint(address,uint256)'](user.address, deposit);
+        await dlcBtc['burn(address,uint256)'](user.address, deposit);
         expect(await dlcBtc.balanceOf(user.address)).to.equal(0);
     });
 
     describe('after Ownership transfer', async () => {
         beforeEach(async () => {
-            await dlcBtc.mint(user.address, deposit);
+            await dlcBtc['mint(address,uint256)'](user.address, deposit);
             await dlcBtc.transferOwnership(tokenManager.address);
         });
 
@@ -108,13 +108,17 @@ describe('DLCBTC', function () {
 
         it('should revert on mint called by previous owner', async () => {
             await expect(
-                dlcBtc.connect(deployer).mint(user.address, deposit)
+                dlcBtc
+                    .connect(deployer)
+                    ['mint(address,uint256)'](user.address, deposit)
             ).to.be.revertedWithCustomError(dlcBtc, 'NotAuthorized');
         });
 
         it('should revert on burn called by previous owner', async () => {
             await expect(
-                dlcBtc.connect(deployer).burn(user.address, deposit)
+                dlcBtc
+                    .connect(deployer)
+                    ['burn(address,uint256)'](user.address, deposit)
             ).to.be.revertedWithCustomError(dlcBtc, 'NotAuthorized');
         });
 


### PR DESCRIPTION
Overloading `burn(uint256 amount)` & `mint(uint256 amount)` functions to support easier CCIP integration