### PR TITLE
fix: minterOrOwner

### DIFF
--- a/contracts/DLCBTC.sol
+++ b/contracts/DLCBTC.sol
@@ -51,8 +51,9 @@ contract DLCBTC is
         __ERC20Permit_init("dlcBTC");
     }
 
-    modifier onlyCCIPMinter() {
-        if (msg.sender != _minter) revert NotAuthorized();
+    modifier onlyOwnerOrCCIPMinter() {
+        if (msg.sender != _minter && msg.sender != owner())
+            revert NotAuthorized();
         _;
     }
 
@@ -66,12 +67,8 @@ contract DLCBTC is
         return 8;
     }
 
-    function mint(address to, uint256 amount) external onlyOwner {
+    function mint(address to, uint256 amount) external onlyOwnerOrCCIPMinter {
         _mint(to, amount);
-    }
-
-    function mint(uint256 amount) external onlyCCIPMinter {
-        _mint(msg.sender, amount);
     }
 
     function burn(address from, uint256 amount) external onlyOwner {

--- a/deploymentFiles/arbitrum/DLCBTC.json
+++ b/deploymentFiles/arbitrum/DLCBTC.json
@@ -1,7 +1,7 @@
 {
   "network": "arbitrum",
-  "updatedAt": "2024-06-13T17:20:24.120Z",
-  "gitSHA": "2453cea",
+  "updatedAt": "2024-06-17T14:33:28.663Z",
+  "gitSHA": "b0905e1",
   "contract": {
     "name": "DLCBTC",
     "address": "0x050C24dBf1eEc17babE5fc585F06116A259CC77A",
@@ -34,7 +34,6 @@
       "function increaseAllowance(address spender, uint256 addedValue) returns (bool)",
       "function initialize()",
       "function mint(address to, uint256 amount)",
-      "function mint(uint256 amount)",
       "function name() view returns (string)",
       "function nonces(address owner) view returns (uint256)",
       "function owner() view returns (address)",

--- a/deploymentFiles/arbsepolia/DLCBTC.json
+++ b/deploymentFiles/arbsepolia/DLCBTC.json
@@ -1,7 +1,7 @@
 {
   "network": "arbsepolia",
-  "updatedAt": "2024-06-13T17:34:21.535Z",
-  "gitSHA": "2453cea",
+  "updatedAt": "2024-06-17T13:33:28.663Z",
+  "gitSHA": "b0905e1",
   "contract": {
     "name": "DLCBTC",
     "address": "0xFfb72b5f195F18741101A732e7AfAE72b61D48a4",
@@ -34,7 +34,6 @@
       "function increaseAllowance(address spender, uint256 addedValue) returns (bool)",
       "function initialize()",
       "function mint(address to, uint256 amount)",
-      "function mint(uint256 amount)",
       "function name() view returns (string)",
       "function nonces(address owner) view returns (uint256)",
       "function owner() view returns (address)",

--- a/deploymentFiles/mainnet/DLCBTC.json
+++ b/deploymentFiles/mainnet/DLCBTC.json
@@ -1,7 +1,7 @@
 {
   "network": "mainnet",
-  "updatedAt": "2024-06-13T17:27:24.120Z",
-  "gitSHA": "2453cea",
+  "updatedAt": "2024-06-17T14:29:04.379Z",
+  "gitSHA": "b0905e1",
   "contract": {
     "name": "DLCBTC",
     "address": "0x20157DBAbb84e3BBFE68C349d0d44E48AE7B5AD2",
@@ -34,7 +34,6 @@
       "function increaseAllowance(address spender, uint256 addedValue) returns (bool)",
       "function initialize()",
       "function mint(address to, uint256 amount)",
-      "function mint(uint256 amount)",
       "function name() view returns (string)",
       "function nonces(address owner) view returns (uint256)",
       "function owner() view returns (address)",

--- a/test/DLCBTC.test.js
+++ b/test/DLCBTC.test.js
@@ -76,7 +76,7 @@ describe('DLCBTC', function () {
     it('should revert on unauthorized mint', async () => {
         await expect(
             dlcBtc.connect(user)['mint(address,uint256)'](user.address, deposit)
-        ).to.be.revertedWith('Ownable: caller is not the owner');
+        ).to.be.revertedWithCustomError(dlcBtc, 'NotAuthorized');
     });
 
     it('should revert on unauthorized burn', async () => {
@@ -111,7 +111,7 @@ describe('DLCBTC', function () {
                 dlcBtc
                     .connect(deployer)
                     ['mint(address,uint256)'](user.address, deposit)
-            ).to.be.revertedWith('Ownable: caller is not the owner');
+            ).to.be.revertedWithCustomError(dlcBtc, 'NotAuthorized');
         });
 
         it('should revert on burn called by previous owner', async () => {


### PR DESCRIPTION
Changing and redeploying token contract. 

CCIP requires an asymmetric setup: `mint(to, amount)`, but `burn(amount)` function signatures. Adjusting the roles and the functions to match this requirement. 

Also redeployed to ArbSepolia, Arbitrum, Mainnet.