### PR TITLE
Add Base PoR address

### DIFF
--- a/scripts/helpers/chainlink-por-addresses.js
+++ b/scripts/helpers/chainlink-por-addresses.js
@@ -20,7 +20,7 @@ module.exports = async function getPoRAddress(network) {
         case 'arbsepolia':
             return '';
         case 'base':
-            return '';
+            return '0x30A76F4E688Cf52f4A06D7AAd987A7037f3Ae6f7';
         case 'basesepolia':
             return '';
         case 'localhost':


### PR DESCRIPTION
Address update:

* [`scripts/helpers/chainlink-por-addresses.js`](diffhunk://#diff-f9ca4276266d0155c9cd8ff03ac781f46c2dce99745541c424142ca9b995caafL23-R23): Updated the address returned for the 'base' network from an empty string to '0x30A76F4E688Cf52f4A06D7AAd987A7037f3Ae6f7'.