### PR TITLE
Merchant specific BTC Fee Rates 

### DIFF
--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -612,15 +612,6 @@ contract DLCManager is
         return addressRate == 0 ? btcRedeemFeeRate : addressRate - 1; // Unshifting to true value
     }
 
-    function getFeeRatesForAddress(
-        address user
-    ) public view returns (uint256, uint256) {
-        uint256 mintFeeRate = getMintFeeRateForAddress(user);
-        uint256 redeemFeeRate = getRedeemFeeRateForAddress(user);
-
-        return (mintFeeRate, redeemFeeRate);
-    }
-
     ////////////////////////////////////////////////////////////////
     //                      ADMIN FUNCTIONS                       //
     ////////////////////////////////////////////////////////////////

--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -74,7 +74,9 @@ contract DLCManager is
     uint256 public totalValueMinted;
     mapping(address => uint256) public btcMintFeeRates;
     mapping(address => uint256) public btcRedeemFeeRates;
-    uint256[36] __gap;
+    mapping(address => bool) private _btcMintFeeRatesSet;
+    mapping(address => bool) private _btcRedeemFeeRatesSet;
+    uint256[34] __gap;
 
     ////////////////////////////////////////////////////////////////
     //                           ERRORS                           //
@@ -604,10 +606,10 @@ contract DLCManager is
         uint256 mintFeeRate = btcMintFeeRates[user];
         uint256 redeemFeeRate = btcRedeemFeeRates[user];
 
-        if (mintFeeRate == 0 && mintFeeRate != btcMintFeeRate) {
+        if (!_btcMintFeeRatesSet[user]) {
             mintFeeRate = btcMintFeeRate;
         }
-        if (redeemFeeRate == 0 && redeemFeeRate != btcRedeemFeeRate) {
+        if (!_btcRedeemFeeRatesSet[user]) {
             redeemFeeRate = btcRedeemFeeRate;
         }
         return (mintFeeRate, redeemFeeRate);
@@ -767,6 +769,7 @@ contract DLCManager is
         if (newBtcMintFeeRate > 10000)
             revert FeeRateOutOfBounds(newBtcMintFeeRate);
         btcMintFeeRates[user] = newBtcMintFeeRate;
+        _btcMintFeeRatesSet[user] = true;
         emit SetBtcMintFeeRateForAddress(user, newBtcMintFeeRate);
     }
 
@@ -777,6 +780,7 @@ contract DLCManager is
         if (newBtcRedeemFeeRate > 10000)
             revert FeeRateOutOfBounds(newBtcRedeemFeeRate);
         btcRedeemFeeRates[user] = newBtcRedeemFeeRate;
+        _btcRedeemFeeRatesSet[user] = true;
         emit SetBtcRedeemFeeRateForAddress(user, newBtcRedeemFeeRate);
     }
 }

--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -72,11 +72,9 @@ contract DLCManager is
     AggregatorV3Interface public dlcBTCPoRFeed;
     mapping(address => mapping(bytes32 => bool)) private _seenSigners;
     uint256 public totalValueMinted;
-    mapping(address => uint256) public btcMintFeeRates;
-    mapping(address => uint256) public btcRedeemFeeRates;
-    mapping(address => bool) private _btcMintFeeRatesSet;
-    mapping(address => bool) private _btcRedeemFeeRatesSet;
-    uint256[34] __gap;
+    mapping(address => uint256) private _btcMintFeeRates;
+    mapping(address => uint256) private _btcRedeemFeeRates;
+    uint256[36] __gap;
 
     ////////////////////////////////////////////////////////////////
     //                           ERRORS                           //
@@ -600,18 +598,26 @@ contract DLCManager is
         return _signerCount;
     }
 
+    function getMintFeeRateForAddress(
+        address user
+    ) public view returns (uint256) {
+        uint256 addressRate = _btcMintFeeRates[user];
+        return addressRate == 0 ? btcMintFeeRate : addressRate - 1; // Unshifting to true value
+    }
+
+    function getRedeemFeeRateForAddress(
+        address user
+    ) public view returns (uint256) {
+        uint256 addressRate = _btcRedeemFeeRates[user];
+        return addressRate == 0 ? btcRedeemFeeRate : addressRate - 1; // Unshifting to true value
+    }
+
     function getFeeRatesForAddress(
         address user
     ) public view returns (uint256, uint256) {
-        uint256 mintFeeRate = btcMintFeeRates[user];
-        uint256 redeemFeeRate = btcRedeemFeeRates[user];
+        uint256 mintFeeRate = getMintFeeRateForAddress(user);
+        uint256 redeemFeeRate = getRedeemFeeRateForAddress(user);
 
-        if (!_btcMintFeeRatesSet[user]) {
-            mintFeeRate = btcMintFeeRate;
-        }
-        if (!_btcRedeemFeeRatesSet[user]) {
-            redeemFeeRate = btcRedeemFeeRate;
-        }
         return (mintFeeRate, redeemFeeRate);
     }
 
@@ -768,8 +774,7 @@ contract DLCManager is
     ) external onlyAdmin {
         if (newBtcMintFeeRate > 10000)
             revert FeeRateOutOfBounds(newBtcMintFeeRate);
-        btcMintFeeRates[user] = newBtcMintFeeRate;
-        _btcMintFeeRatesSet[user] = true;
+        _btcMintFeeRates[user] = newBtcMintFeeRate + 1; // Shifted by 1 to easily store a deliberate value of 0
         emit SetBtcMintFeeRateForAddress(user, newBtcMintFeeRate);
     }
 
@@ -779,8 +784,7 @@ contract DLCManager is
     ) external onlyAdmin {
         if (newBtcRedeemFeeRate > 10000)
             revert FeeRateOutOfBounds(newBtcRedeemFeeRate);
-        btcRedeemFeeRates[user] = newBtcRedeemFeeRate;
-        _btcRedeemFeeRatesSet[user] = true;
+        _btcRedeemFeeRates[user] = newBtcRedeemFeeRate + 1; // Shifted by 1 to easily store a deliberate value of 0
         emit SetBtcRedeemFeeRateForAddress(user, newBtcRedeemFeeRate);
     }
 }

--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -72,7 +72,9 @@ contract DLCManager is
     AggregatorV3Interface public dlcBTCPoRFeed;
     mapping(address => mapping(bytes32 => bool)) private _seenSigners;
     uint256 public totalValueMinted;
-    uint256[38] __gap;
+    mapping(address => uint256) public btcMintFeeRates;
+    mapping(address => uint256) public btcRedeemFeeRates;
+    uint256[36] __gap;
 
     ////////////////////////////////////////////////////////////////
     //                           ERRORS                           //
@@ -218,6 +220,14 @@ contract DLCManager is
     event TransferTokenContractOwnership(address newOwner);
     event SetPorEnabled(bool enabled);
     event SetDlcBTCPoRFeed(AggregatorV3Interface feed);
+    event SetBtcMintFeeRateForAddress(
+        address indexed user,
+        uint256 newBtcMintFeeRate
+    );
+    event SetBtcRedeemFeeRateForAddress(
+        address indexed user,
+        uint256 newBtcRedeemFeeRate
+    );
 
     ////////////////////////////////////////////////////////////////
     //                    INTERNAL FUNCTIONS                      //
@@ -588,6 +598,21 @@ contract DLCManager is
         return _signerCount;
     }
 
+    function getFeeRatesForAddress(
+        address user
+    ) public view returns (uint256, uint256) {
+        uint256 mintFeeRate = btcMintFeeRates[user];
+        uint256 redeemFeeRate = btcRedeemFeeRates[user];
+
+        if (mintFeeRate == 0 && mintFeeRate != btcMintFeeRate) {
+            mintFeeRate = btcMintFeeRate;
+        }
+        if (redeemFeeRate == 0 && redeemFeeRate != btcRedeemFeeRate) {
+            redeemFeeRate = btcRedeemFeeRate;
+        }
+        return (mintFeeRate, redeemFeeRate);
+    }
+
     ////////////////////////////////////////////////////////////////
     //                      ADMIN FUNCTIONS                       //
     ////////////////////////////////////////////////////////////////
@@ -733,5 +758,25 @@ contract DLCManager is
     function setDlcBTCPoRFeed(AggregatorV3Interface feed) external onlyAdmin {
         dlcBTCPoRFeed = feed;
         emit SetDlcBTCPoRFeed(feed);
+    }
+
+    function setBtcMintFeeRateForAddress(
+        address user,
+        uint256 newBtcMintFeeRate
+    ) external onlyAdmin {
+        if (newBtcMintFeeRate > 10000)
+            revert FeeRateOutOfBounds(newBtcMintFeeRate);
+        btcMintFeeRates[user] = newBtcMintFeeRate;
+        emit SetBtcMintFeeRateForAddress(user, newBtcMintFeeRate);
+    }
+
+    function setBtcRedeemFeeRateForAddress(
+        address user,
+        uint256 newBtcRedeemFeeRate
+    ) external onlyAdmin {
+        if (newBtcRedeemFeeRate > 10000)
+            revert FeeRateOutOfBounds(newBtcRedeemFeeRate);
+        btcRedeemFeeRates[user] = newBtcRedeemFeeRate;
+        emit SetBtcRedeemFeeRateForAddress(user, newBtcRedeemFeeRate);
     }
 }

--- a/contracts/DLCManager.sol
+++ b/contracts/DLCManager.sol
@@ -598,6 +598,12 @@ contract DLCManager is
         return _signerCount;
     }
 
+    /// @notice Get the mint fee rate for a specific address
+    /// @dev The stored rate is shifted by +1 to differentiate between unset (0) and 0% fee rate
+    /// If the rate is 0 (unset), returns the default btcMintFeeRate
+    /// Otherwise returns the stored rate minus 1 to get the true value
+    /// @param user The address to get the mint fee rate for
+    /// @return The mint fee rate for the given address
     function getMintFeeRateForAddress(
         address user
     ) public view returns (uint256) {
@@ -605,6 +611,12 @@ contract DLCManager is
         return addressRate == 0 ? btcMintFeeRate : addressRate - 1; // Unshifting to true value
     }
 
+    /// @notice Get the redeem fee rate for a specific address
+    /// @dev The stored rate is shifted by +1 to differentiate between unset (0) and 0% fee rate
+    /// If the rate is 0 (unset), returns the default btcRedeemFeeRate
+    /// Otherwise returns the stored rate minus 1 to get the true value
+    /// @param user The address to get the redeem fee rate for
+    /// @return The redeem fee rate for the given address
     function getRedeemFeeRateForAddress(
         address user
     ) public view returns (uint256) {
@@ -759,6 +771,12 @@ contract DLCManager is
         emit SetDlcBTCPoRFeed(feed);
     }
 
+    /// @notice Sets Bitcoin minting fee rate for a specific address
+    /// @dev Increments the fee rate by 1 to distinguish between unset (0) and deliberately set zero (1) values.
+    /// @dev This helps identify if a fee rate was explicitly set to 0 vs never being set.
+    /// @param user The address to set the fee rate for
+    /// @param newBtcMintFeeRate The fee rate to set (0-10000)
+    /// @custom:throws FeeRateOutOfBounds if newBtcMintFeeRate > 10000
     function setBtcMintFeeRateForAddress(
         address user,
         uint256 newBtcMintFeeRate
@@ -769,6 +787,12 @@ contract DLCManager is
         emit SetBtcMintFeeRateForAddress(user, newBtcMintFeeRate);
     }
 
+    /// @notice Sets Bitcoin redemption fee rate for a specific address
+    /// @dev Increments the fee rate by 1 to distinguish between unset (0) and deliberately set zero (1) values.
+    /// @dev This helps identify if a fee rate was explicitly set to 0 vs never being set.
+    /// @param user The address to set the fee rate for
+    /// @param newBtcRedeemFeeRate The fee rate to set (0-10000)
+    /// @custom:throws FeeRateOutOfBounds if newBtcRedeemFeeRate > 10000
     function setBtcRedeemFeeRateForAddress(
         address user,
         uint256 newBtcRedeemFeeRate

--- a/test/DLCManager.test.js
+++ b/test/DLCManager.test.js
@@ -223,6 +223,44 @@ describe('DLCManager', () => {
         });
     });
 
+    describe('Mint fee rate for Address', async () => {
+        it('returns default value if unset', async () => {
+            const feeRate = await dlcManager.getMintFeeRateForAddress(
+                randomAccount.address
+            );
+            expect(feeRate).to.equal(12); // NOTE: If this test is failing, you probably changed the default value on the contract.
+        });
+        it('returns the correct value after setting', async () => {
+            const newRate = 1000;
+            await dlcManager
+                .connect(deployer)
+                .setBtcMintFeeRateForAddress(randomAccount.address, newRate);
+            const feeRate = await dlcManager.getMintFeeRateForAddress(
+                randomAccount.address
+            );
+            expect(feeRate).to.equal(newRate);
+        });
+    });
+
+    describe('Redeem fee rate for Address', async () => {
+        it('returns default value if unset', async () => {
+            const feeRate = await dlcManager.getRedeemFeeRateForAddress(
+                randomAccount.address
+            );
+            expect(feeRate).to.equal(15); // NOTE: If this test is failing, you probably changed the default value on the contract.
+        });
+        it('returns the correct value after setting', async () => {
+            const newRate = 1000;
+            await dlcManager
+                .connect(deployer)
+                .setBtcRedeemFeeRateForAddress(randomAccount.address, newRate);
+            const feeRate = await dlcManager.getRedeemFeeRateForAddress(
+                randomAccount.address
+            );
+            expect(feeRate).to.equal(newRate);
+        });
+    });
+
     describe('setupVault', async () => {
         it('reverts if called by a non-whitelisted user', async () => {
             await expect(


### PR DESCRIPTION
Adds support for setting custom fee rates for a single address.

If there is nothing set, it uses the default global fee rates.