### PR TITLE
chore(ci): added dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions-all:
+        update-types:
+          - major
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` matching the pattern in [`dec-party-manager`](https://github.com/DLC-Link/dec-party-manager):

- Monthly npm updates at `/`, grouped minor/patch, conventional commit prefixes
- Monthly github-actions updates if workflows exist

Part of the org-wide security tooling rollout. `cargo-audit` / `cargo-deny` don't apply (no Rust).

## Test plan
- [ ] Dependabot picks up the config (Insights → Dependency graph → Dependabot)
- [ ] First scheduled run produces grouped PRs as expected